### PR TITLE
make 'alarmOn' field private

### DIFF
--- a/java/src/main/java/org/example/Alarm.java
+++ b/java/src/main/java/org/example/Alarm.java
@@ -7,7 +7,7 @@ public class Alarm {
 
     protected Sensor sensor = new Sensor();
 
-    boolean alarmOn = false;
+    private boolean alarmOn = false;
 
 
     public void check()


### PR DESCRIPTION
Don't see why its supposed to be accessible. Also, in other languages it's private