### PR TITLE
Fix comparison mistake in Swift variant

### DIFF
--- a/swift/TirePressure/Sources/TirePressure/Alarm.swift
+++ b/swift/TirePressure/Sources/TirePressure/Alarm.swift
@@ -12,7 +12,7 @@ public class Alarm {
     public func check() {
         let psiPressureValue = _sensor.PopNextPressurePsiValue()
 
-        if (psiPressureValue > lowPressureThreshold || highPressureThreshold < psiPressureValue) {
+        if (psiPressureValue < lowPressureThreshold || highPressureThreshold < psiPressureValue) {
             _alarmOn = true
             _alarmCount += 1
         }


### PR DESCRIPTION
Hello,

While exercising on this kata, I realised I made a mistake regarding the pressure value's comparison in Alarm.swift

I apologise for this situation, demonstrating how strong I have to practice TDD

Best regards,
Anthony